### PR TITLE
Update pyface and traitsui version requirement following last release

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,32 +23,12 @@ Install anaconda for your platform and run
 ```bash
 conda install hyperspy-gui-traitsui -c conda-forge
 
-```
-traitsui doesn't support Qt5 as of version 5.1. Therefore, when using the
-Qt toolkit it may be necessary to downgrade pyqt, which requires removing
-the anaconda-navigator and the navigator-updater packages as follows:
-
-```bash
-conda remove anaconda-navigator navigator-updater
-```
-
-## qt5 support (for advanced pip users only)
-
-Alternatively, it you want to use Qt5, you can install the development 
-version of traitsui (and pyface) which supports Qt5. You will need to 
-have the development tools to build C code installed on your system.
-
-```bash
-pip install https://github.com/enthought/pyface/archive/master.zip
-pip install https://github.com/enthought/traitsui/archive/master.zip
-```
-
 ## Usage
 
 Please refer to the [HyperSpy documentation](http://hyperspy.org/hyperspy-doc/current/index.html) for details. Example (to run in any IPython flavour):
 
 ```python
-%matplotlib qt4
+%matplotlib qt
 import hyperspy.api as hs
 hs.preferences.gui(toolkit="traitsui")
 ```

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['hyperspy>=1.3', 'traitsui>=5.0'],
+    install_requires=['hyperspy>=1.3', 'traitsui>=6.0'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
pyface and traitsui version 6.0.0 are out!
- [x] Update traitsui version requirement to 6.0.0 to support pyqt5,
- [x] remove explanation to downgrade to qt4 in `README.md`.