### PR TITLE
Fix reset function of the image contrast handler

### DIFF
--- a/hyperspy_gui_traitsui/tools.py
+++ b/hyperspy_gui_traitsui/tools.py
@@ -110,21 +110,13 @@ class ImageContrastHandler(tu.Handler):
 
         return
 
-    @staticmethod
-    def reset(info):
-        """Handles the **Apply** button being clicked.
+    def reset(self, info):
+        """Handles the **Reset** button being clicked.
 
         """
         obj = info.object
         obj.reset()
         return
-
-    @staticmethod
-    def our_help(info):
-        """Handles the **Apply** button being clicked.
-
-        """
-        info.object._help()
 
 
 @register_traitsui_widget(toolkey="Signal1D.calibrate")


### PR DESCRIPTION
This PR fixes the callback of the reset button:

```python
import numpy as np
import hyperspy.api as hs
hs.preferences.GUIs.enable_traitsui_gui = True

s = hs.signals.Signal2D(np.arange(100).reshape(10,10))
s.plot()
s._plot.signal_plot.gui_adjust_contrast()
# Interactively change the contrast and then press the reset button
```
