### PR TITLE
Attempt to make the warning about unsupported matplotlib backend more useful

### DIFF
--- a/hyperspy_gui_traitsui/__init__.py
+++ b/hyperspy_gui_traitsui/__init__.py
@@ -67,7 +67,9 @@ elif ETSConfig.toolkit == "":
             "The {} matplotlib backend is not supported by the "
             "installed traitsui version and the ETS toolkit has been set to null. "
             "To set the ETS toolkit independently from the matplotlib backend, "
-            "set it before importing matplotlib.".format(matplotlib.get_backend()))
+            "set it before importing matplotlib. See "
+            "http://hyperspy.readthedocs.io/en/stable/user_guide/getting_started.html "
+            "for more information.".format(matplotlib.get_backend()))
 
 if ETSConfig.toolkit and ETSConfig.toolkit != "null":
     import hyperspy.api_nogui # necessary to register the toolkeys


### PR DESCRIPTION
As discussed in https://github.com/hyperspy/hyperspy/issues/1898, add a link to the getting started section of the user guide when the ETS toolkit is set to null, so that users can find out where the mistake is or where to disable this warning.