### PR TITLE
Fix issue when using notebook backend

### DIFF
--- a/hyperspy_gui_traitsui/tools.py
+++ b/hyperspy_gui_traitsui/tools.py
@@ -1,6 +1,5 @@
 from traitsui.menu import (OKButton, CancelButton, OKCancelButtons)
 import traitsui.api as tu
-from traitsui.qt4.extra.bounds_editor import BoundsEditor
 
 from hyperspy_gui_traitsui.buttons import *
 from hyperspy_gui_traitsui.utils import add_display_arg
@@ -263,6 +262,7 @@ def load(obj, **kwargs):
 
 @add_display_arg
 def image_constast_editor_traitsui(obj, **kwargs):
+    from traitsui.qt4.extra.bounds_editor import BoundsEditor
 
     view = tu.View(
         tu.Group(


### PR DESCRIPTION
Move import requiring the 'qt' backend to fix issue when importing `tools` and not using the qt backend, for example when using the notebook matplotlib, which disable the traitsui widgets (these can be still imported).

To reproduce, run in a notebook:
```python
%matplotlib notebook
import hyperspy.api as hs
s = hs.datasets.artificial_data.get_core_loss_eels_line_scan_signal(True)
s.remove_background()
```

```python
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-3-00364798c3b1> in <module>
----> 1 s.remove_background()

~/Dev/hyperspy/hyperspy/_signals/signal1d.py in remove_background(self, signal_range, background_type, polynomial_order, fast, zero_fill, plot_remainder, show_progressbar, return_model, display, toolkit)
   1235                                    zero_fill=zero_fill,
   1236                                    model=model)
-> 1237             gui_dict = br.gui(display=display, toolkit=toolkit)
   1238             if return_model:
   1239                 return model

~/Dev/hyperspy/hyperspy/ui_registry.py in pg(self, display, toolkit, **kwargs)
    166     def pg(self, display=True, toolkit=None, **kwargs):
    167         return get_gui(self, toolkey=toolkey, display=display,
--> 168                        toolkit=toolkit, **kwargs)
    169     return pg
    170 

~/Dev/hyperspy/hyperspy/ui_registry.py in get_gui(self, toolkey, display, toolkit, **kwargs)
    135         f = getattr(
    136             importlib.import_module(
--> 137                 specs["module"]),
    138             specs["function"])
    139         if toolkit in toolkits:

/opt/miniconda3/lib/python3.7/importlib/__init__.py in import_module(name, package)
    125                 break
    126             level += 1
--> 127     return _bootstrap._gcd_import(name[level:], package, level)
    128 
    129 

/opt/miniconda3/lib/python3.7/importlib/_bootstrap.py in _gcd_import(name, package, level)

/opt/miniconda3/lib/python3.7/importlib/_bootstrap.py in _find_and_load(name, import_)

/opt/miniconda3/lib/python3.7/importlib/_bootstrap.py in _find_and_load_unlocked(name, import_)

/opt/miniconda3/lib/python3.7/importlib/_bootstrap.py in _load_unlocked(spec)

/opt/miniconda3/lib/python3.7/importlib/_bootstrap_external.py in exec_module(self, module)

/opt/miniconda3/lib/python3.7/importlib/_bootstrap.py in _call_with_frames_removed(f, *args, **kwds)

~/Dev/hyperspy_gui_traitsui/hyperspy_gui_traitsui/tools.py in <module>
      1 from traitsui.menu import (OKButton, CancelButton, OKCancelButtons)
      2 import traitsui.api as tu
----> 3 from traitsui.qt4.extra.bounds_editor import BoundsEditor
      4 
      5 from hyperspy_gui_traitsui.buttons import *

/opt/miniconda3/lib/python3.7/site-packages/traitsui/qt4/__init__.py in <module>
     23 # ----------------------------------------------------------------------------
     24 
---> 25 from . import toolkit
     26 
     27 # Reference to the GUIToolkit object for Qt.

/opt/miniconda3/lib/python3.7/site-packages/traitsui/qt4/toolkit.py in <module>
     19 from traitsui.toolkit import assert_toolkit_import
     20 
---> 21 assert_toolkit_import(["qt4", "qt"])
     22 
     23 # Ensure that we can import Pyface backend.  This starts App as a side-effect.

/opt/miniconda3/lib/python3.7/site-packages/traitsui/toolkit.py in assert_toolkit_import(names)
     42         raise RuntimeError(
     43             "Importing from %s backend after selecting %s "
---> 44             "backend!" % (names[0], ETSConfig.toolkit)
     45         )
     46 

RuntimeError: Importing from qt4 backend after selecting null backend!
```