### PR TITLE
Add is binned axis gui

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,14 +5,16 @@
 1.5.0.dev0 (Unreleased)
 -----------------------
 
+* Add `is_binned` to axis GUI, make index of the navigation axis editable (`#39 https://github.com/hyperspy/hyperspy_gui_traitsui/pull/39`_)
+* Fix loading GUI (`#38 https://github.com/hyperspy/hyperspy_gui_traitsui/pull/38`_)
 
 
 1.4.0
 -----
 The is a minor release:
 
-* Fix closing contrast editor tool.
-* Add iterpath to fit component GUI.
-* Make axes gui compatible with non-unform axis.
-* Use GitHub Actions to run the test suite and make release.
+* Fix closing contrast editor tool (`#35 https://github.com/hyperspy/hyperspy_gui_traitsui/pull/35`_)
+* Add iterpath to fit component GUI (`#34 https://github.com/hyperspy/hyperspy_gui_traitsui/pull/34`_)
+* Make axes gui compatible with non-unform axis (`#25 https://github.com/hyperspy/hyperspy_gui_traitsui/pull/25`_)
+* Use GitHub Actions to run the test suite and make release (`#32 https://github.com/hyperspy/hyperspy_gui_traitsui/pull/32`_)
 

--- a/hyperspy_gui_traitsui/axes.py
+++ b/hyperspy_gui_traitsui/axes.py
@@ -87,62 +87,21 @@ def get_navigation_sliders_group(obj):
     return axis_group, context
 
 
-def _get_data_axis_view(obj):
-    label = get_axis_label(obj)
-
-    group_args = [
-        tui.Item(name='name'),
-        tui.Item(name='size', style='readonly'),
-        tui.Item(name='index_in_array', style='readonly'),
-        tui.Item(name='units'),
-        tui.Item(name='is_binned'),
-    ]
-    cal_args = [ ]
-
-    if obj.navigate:
-        group_args.extend([
-            tui.Item(name='index'),
-            tui.Item(name='value', style='readonly'), ])
-    if hasattr(obj, 'scale'):
-        cal_args.extend([
-            tui.Item(name='scale'),
-            tui.Item(name='offset'), ])
-    if hasattr(obj, '_expression'):
-        cal_args.extend([
-            tui.Item(name='_expression', style='readonly'), ])
-        for parameter in obj.parameters_list:
-            cal_args.extend([
-                tui.Item(name=parameter, style='readonly'), ])
-        if hasattr(obj.x, 'scale'):
-            cal_args.extend([
-                tui.Item(name='x.scale'),
-                tui.Item(name='x.offset'), ])
-
-    if cal_args == [ ]:
-        data_axis_view = tui.View(
-            tui.Group(
-                tui.Group(*group_args,
-                          show_border=True,),
-                # label="Data Axis properties",
-                show_border=True,),
-            title=label,)
-    else:
-        data_axis_view = tui.View(
-            tui.Group(
-                tui.Group(*group_args,
-                          show_border=True,),
-                tui.Group(*cal_args,
-                          label='Calibration', show_border=True, ),
-                # label="Data Axis properties",
-                show_border=True,),
-            title=label,)
-
-    return data_axis_view
-
-
 @add_display_arg
 def axis_gui(obj, **kwargs):
-    return obj, {"view": _get_data_axis_view(obj)}
+    context = {'axis0': obj}
+    kwargs = {}
+    if hasattr(obj, 'parameters_list'):
+        kwargs["parameters_list"] = obj.parameters_list
+        if hasattr(obj.x, 'scale'):
+            kwargs["xscale"] = obj.x.scale
+    ag = get_axis_group(n=0,
+                        navigate=obj.navigate,
+                        attribs=obj.__dict__.keys(),
+                        **kwargs
+                        )
+    obj.trait_view("traits_view", tui.View(ag, title="Axis GUI"))
+    return obj, {"context": context}
 
 
 def get_axis_group(n, navigate, label='', attribs=[], **kwargs):

--- a/hyperspy_gui_traitsui/axes.py
+++ b/hyperspy_gui_traitsui/axes.py
@@ -77,7 +77,7 @@ def get_navigation_sliders_group(obj):
                                                 low_name=f'axis{i}.low_value',
                                                 high_name=f'axis{i}.high_value',
                                                 label_width=28,
-                                                format='%i',
+                                                format_str='%5g',
                                                 mode='auto')))
         context[f'axis{i}'] = axis
 
@@ -115,13 +115,15 @@ def get_axis_group(n, navigate, label='', attribs=[], **kwargs):
         tui.Item(f'axis{n}.is_binned'),
     ]
     cal_args = [ ]
-    # The style of the index is chosen to be readonly because of
-    # a bug in Traits 4.0.0 when using context with a Range traits
-    # where the limits are defined by another traits_view
     if navigate:
         group_args.extend([
-            tui.Item(f'axis{n}.index', style='readonly'),
-            tui.Item(f'axis{n}.value', style='readonly'), ])
+            tui.Item(f'axis{n}.index', editor=tui.RangeEditor(
+                                                low_name=f'axis{n}.low_index',
+                                                high_name=f'axis{n}.high_index',
+                                                label_width=28,
+                                                format_str='%i',
+                                                mode='auto')),
+            tui.Item(f'axis{n}.value', style='readonly', format_str='%5g'), ])
     if 'scale' in attribs:
         cal_args.extend([
             tui.Item(f'axis{n}.scale'),

--- a/hyperspy_gui_traitsui/axes.py
+++ b/hyperspy_gui_traitsui/axes.py
@@ -95,6 +95,7 @@ def _get_data_axis_view(obj):
         tui.Item(name='size', style='readonly'),
         tui.Item(name='index_in_array', style='readonly'),
         tui.Item(name='units'),
+        tui.Item(name='is_binned'),
     ]
     cal_args = [ ]
 
@@ -147,12 +148,13 @@ def data_axis_traitsui(obj, **kwargs):
 
 def get_axis_group(n, navigate, label='', attribs = [], **kwargs):
     group_args = [
-        tui.Item('axis%i.name' % n),
-        tui.Item('axis%i.size' % n, style='readonly'),
-        tui.Item('axis%i.index_in_array' % n, style='readonly'),
-        tui.Item('axis%i.low_index' % n, style='readonly'),
-        tui.Item('axis%i.high_index' % n, style='readonly'),
-        tui.Item('axis%i.units' % n),
+        tui.Item(f'axis{n}.name'),
+        tui.Item(f'axis{n}.size', style='readonly'),
+        tui.Item(f'axis{n}.index_in_array', style='readonly'),
+        tui.Item(f'axis{n}.low_index', style='readonly'),
+        tui.Item(f'axis{n}.high_index', style='readonly'),
+        tui.Item(f'axis{n}.units'),
+        tui.Item(f'axis{n}.is_binned'),
     ]
     cal_args = [ ]
     # The style of the index is chosen to be readonly because of

--- a/hyperspy_gui_traitsui/axes.py
+++ b/hyperspy_gui_traitsui/axes.py
@@ -112,9 +112,10 @@ def get_axis_group(n, navigate, label='', attribs=[], **kwargs):
         tui.Item(f'axis{n}.low_index', style='readonly'),
         tui.Item(f'axis{n}.high_index', style='readonly'),
         tui.Item(f'axis{n}.units'),
-        tui.Item(f'axis{n}.is_binned'),
     ]
     cal_args = [ ]
+    if 'is_binned' in attribs:
+        group_args.append(tui.Item(f'axis{n}.is_binned'))
     if navigate:
         group_args.extend([
             tui.Item(f'axis{n}.index', editor=tui.RangeEditor(

--- a/hyperspy_gui_traitsui/axes.py
+++ b/hyperspy_gui_traitsui/axes.py
@@ -110,10 +110,9 @@ def _get_data_axis_view(obj):
     if hasattr(obj, '_expression'):
         cal_args.extend([
             tui.Item(name='_expression', style='readonly'), ])
-            #tui.Item(name='_expression', style='readonly'), ]) # Add parameter of expression
-        for i in obj.parameters_list:
+        for parameter in obj.parameters_list:
             cal_args.extend([
-                tui.Item(name=obj.parameters_list[i], style='readonly'), ])
+                tui.Item(name=parameter, style='readonly'), ])
         if hasattr(obj.x, 'scale'):
             cal_args.extend([
                 tui.Item(name='x.scale'),
@@ -142,11 +141,11 @@ def _get_data_axis_view(obj):
 
 
 @add_display_arg
-def data_axis_traitsui(obj, **kwargs):
+def axis_gui(obj, **kwargs):
     return obj, {"view": _get_data_axis_view(obj)}
 
 
-def get_axis_group(n, navigate, label='', attribs = [], **kwargs):
+def get_axis_group(n, navigate, label='', attribs=[], **kwargs):
     group_args = [
         tui.Item(f'axis{n}.name'),
         tui.Item(f'axis{n}.size', style='readonly'),
@@ -162,22 +161,23 @@ def get_axis_group(n, navigate, label='', attribs = [], **kwargs):
     # where the limits are defined by another traits_view
     if navigate:
         group_args.extend([
-            tui.Item('axis%i.index' % n, style='readonly'),
-            tui.Item('axis%i.value' % n, style='readonly'), ])
+            tui.Item(f'axis{n}.index', style='readonly'),
+            tui.Item(f'axis{n}.value', style='readonly'), ])
     if 'scale' in attribs:
         cal_args.extend([
-            tui.Item('axis%i.scale' % n),
-            tui.Item('axis%i.offset' % n), ])
+            tui.Item(f'axis{n}.scale'),
+            tui.Item(f'axis{n}.offset'), ])
     if '_expression' in attribs:
         cal_args.extend([
-            tui.Item('axis%i._expression' % n, style='readonly'), ])
+            tui.Item(f'axis{n}._expression', style='readonly'), ])
         for j in range(len(kwargs['parameters_list'])):
+            p = kwargs['parameters_list'][j]
             cal_args.extend([
-                tui.Item('axis{n}.{p}'.format(n = n,p = kwargs['parameters_list'][j]), label = kwargs['parameters_list'][j]), ])
+                tui.Item(f'axis{n}.{p}', label=p), ])
         if 'xscale' in kwargs.keys():
             cal_args.extend([
-                tui.Item('axis%i.x.scale' % n, label='x scale'),
-                tui.Item('axis%i.x.offset' % n, label='x offset'), ])
+                tui.Item(f'axis{n}.x.scale', label='x scale'),
+                tui.Item(f'axis{n}.x.offset', label='x offset'), ])
 
     if cal_args == [ ]:
         group = tui.Group(
@@ -202,14 +202,14 @@ def axes_gui(obj, **kwargs):
     ag = []
     for n, axis in enumerate(obj._get_axes_in_natural_order()):
         kwargs = {}
-        if hasattr(axis,'parameters_list'):
+        if hasattr(axis, 'parameters_list'):
             kwargs["parameters_list"] = axis.parameters_list
-            if hasattr(axis.x,'scale'):
+            if hasattr(axis.x, 'scale'):
                 kwargs["xscale"] = axis.x.scale
         ag.append(get_axis_group(
             n, label=get_axis_label(axis), navigate=axis.navigate,
-            attribs=axis.__dict__.keys(),**kwargs))
-        context['axis%i' % n] = axis
+            attribs=axis.__dict__.keys(), **kwargs))
+        context[f'axis{n}'] = axis
     ag = tuple(ag)
     obj.trait_view("traits_view", tui.View(*ag, title="Axes GUI"))
     return obj, {"context": context}

--- a/hyperspy_gui_traitsui/hyperspy_extension.yaml
+++ b/hyperspy_gui_traitsui/hyperspy_extension.yaml
@@ -15,7 +15,7 @@ GUI:
         function: preferences_traitsui
       hyperspy.DataAxis:
         module: hyperspy_gui_traitsui.axes
-        function: data_axis_traitsui
+        function: axis_gui
       hyperspy.AxesManager:
         module: hyperspy_gui_traitsui.axes
         function: axes_gui


### PR DESCRIPTION
- [x] add `is_binned` to axis gui,
- [x] fix `FunctionalDataAxis` axis issue in axes gui only, not the axes manager gui - requires the gui method added in https://github.com/hyperspy/hyperspy/pull/2752
- [x] refactor `axis_gui` to reuse code the code from the `axes_manager` gui,
- [x] specify editor for the index of navigation axis to make it adjustable,
- [x] add entry to changelog,
- [x] ready for review 


`FunctionalDataAxis` axis issue:
```python
import hyperspy.api as hs

s = hs.datasets.artificial_data.get_luminescence_signal(navigation_dimension=1)
s.axes_manager[1].gui()
```
```python
  File "<ipython-input-3-73305998a3ad>", line 1, in <module>
    s.axes_manager[1].gui()

  File "/home/eric/Dev/hyperspy/hyperspy/ui_registry.py", line 163, in pg
    return get_gui(self, toolkey=toolkey, display=display,

  File "/home/eric/Dev/hyperspy/hyperspy/ui_registry.py", line 138, in get_gui
    thisw = f(obj=self, display=display, **kwargs)

  File "/home/eric/Dev/hyperspy_gui_traitsui/hyperspy_gui_traitsui/utils.py", line 9, in wrapper
    obj, kwargs = f(*args, **kwargs)

  File "/home/eric/Dev/hyperspy_gui_traitsui/hyperspy_gui_traitsui/axes.py", line 145, in data_axis_traitsui
    return obj, {"view": _get_data_axis_view(obj)}

  File "/home/eric/Dev/hyperspy_gui_traitsui/hyperspy_gui_traitsui/axes.py", line 115, in _get_data_axis_view
    tui.Item(name=obj.parameters_list[i], style='readonly'), ])

TypeError: list indices must be integers or slices, not str
```