### PR TITLE
Update background removal for hyperspy/hyperspy#2922

### DIFF
--- a/hyperspy_gui_traitsui/tests/test_tools.py
+++ b/hyperspy_gui_traitsui/tests/test_tools.py
@@ -16,10 +16,14 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-import numpy as np
-import hyperspy.api as hs
+from packaging.version import Version
 
-from hyperspy.signal_tools import ImageContrastEditor
+import numpy as np
+import pytest
+
+import hyperspy
+import hyperspy.api as hs
+from hyperspy.signal_tools import ImageContrastEditor, BackgroundRemoval
 
 from hyperspy_gui_traitsui.tests.utils import KWARGS
 
@@ -47,3 +51,20 @@ def test_image_contrast_tool():
     for norm in ['Linear', 'Power', 'Log', 'Symlog']:
         ceditor.norm = norm
         assert ceditor.norm == norm
+
+
+@pytest.mark.skipif(Version(hyperspy.__version__) < Version("1.7.0.dev"),
+                    reason="Only supported for hyperspy>=1.7")
+def test_remove_background_tool():
+
+    s = hs.datasets.artificial_data.get_core_loss_eels_signal(True, False)
+    s.plot()
+
+    BgR = BackgroundRemoval(s)
+    BgR.gui(**KWARGS)
+    BgR.span_selector.extents = (450., 500.)
+    BgR.span_selector_changed()
+    BgR.apply()
+    assert s.isig[:500.0].data.mean() < 1
+
+

--- a/hyperspy_gui_traitsui/tools.py
+++ b/hyperspy_gui_traitsui/tools.py
@@ -25,9 +25,12 @@ class SpanSelectorInSignal1DHandler(tu.Handler):
     def close(self, info, is_ok):
         # Removes the span selector from the plot
         obj = info.object
-        obj.span_selector_switch(False)
+
+        # Apply before switching off the selector
         if is_ok is True:
             self.apply(info)
+        obj.span_selector_switch(False)
+
         if hasattr(obj, 'close'):
             obj.close()
 


### PR DESCRIPTION
Switch off SpanSelector only after applying background selector, as changes to the remove background tool introduced in https://github.com/hyperspy/hyperspy/pull/2922, we check if the SpanSelector is valid before removing the background.

https://github.com/hyperspy/hyperspy/pull/2922 needs to be merged to pass the test.