### PR TITLE
Fix deprecation warning traitsui

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,15 @@ jobs:
             PIP_SELECTOR: '[tests, coverage]'
             LABEL: -RnM-coverage
             PYTEST_ARGS_COVERAGE: --cov=. --cov-report=xml
+          - os: ubuntu
+            PYTHON_VERSION: '3.7'
+            OLDEST_SUPPORTED_VERSION: true
+            # Matching setup.py
+            DEPENDENCIES: traits==4.5 hyperspy==1.6.2 traitsui==6.0
+            PIP_SELECTOR: '[tests]'
+            # Hang at the end of the test suite run...
+            #PYTEST_ARGS_COVERAGE: --cov=. --cov-report=xml
+            LABEL: -oldest
 
     steps:
       - uses: actions/checkout@v3
@@ -42,6 +51,11 @@ jobs:
         run: |
           python --version
           pip --version
+
+      - name: Install oldest supported version
+        if: ${{ matrix.OLDEST_SUPPORTED_VERSION }}
+        run: |
+          pip install ${{ matrix.DEPENDENCIES }}
 
       - name: Install HyperSpy (RELEASE_next_minor)
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
             PYTHON_VERSION: '3.7'
             OLDEST_SUPPORTED_VERSION: true
             # Matching setup.py
-            DEPENDENCIES: traits==4.5 hyperspy==1.6.2 traitsui==6.0
+            DEPENDENCIES: traits==5.0 hyperspy==1.6.2 traitsui==6.1
             PIP_SELECTOR: '[tests]'
             # Hang at the end of the test suite run...
             #PYTEST_ARGS_COVERAGE: --cov=. --cov-report=xml

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 * Improve rendering changelog on github and fix hyperlinks in `README.md` ([#42](https://github.com/hyperspy/hyperspy_gui_traitsui/pull/42)).
 * Speed up import time by importing submodules lazily and drop support for python 3.6 ([#41](https://github.com/hyperspy/hyperspy_gui_traitsui/pull/41)).
 * Add python 3.10 to github CI and update github actions versions ([#43](https://github.com/hyperspy/hyperspy_gui_traitsui/pull/43)).
+* Fix traistui deprecation warning and add oldest supported version of dependencies build to github CI ([#45](https://github.com/hyperspy/hyperspy_gui_traitsui/pull/45))
 
 ## v1.4.0 (2021-04-13)
 

--- a/hyperspy_gui_traitsui/tools.py
+++ b/hyperspy_gui_traitsui/tools.py
@@ -1,3 +1,6 @@
+from packaging.version import Version
+
+import traitsui
 import traitsui.api as tu
 from traitsui.file_dialog import FileEditor
 from traitsui.menu import OKButton, CancelButton, OKCancelButtons
@@ -264,6 +267,14 @@ def load(obj, **kwargs):
 @add_display_arg
 def image_constast_editor_traitsui(obj, **kwargs):
     from traitsui.qt4.extra.bounds_editor import BoundsEditor
+    
+    # format has been deprecated in Release 7.3.0, replaced by format_str
+    # https://github.com/enthought/traitsui/pull/1684
+    # Remove and simplify when minimum traitsui version is 7.3.0
+    FORMAT_STR = 'format' if Version(traitsui.__version__) < Version('7.0.0') \
+        else 'format_str'
+    def get_format_dict(formatting):
+        return {FORMAT_STR:formatting}
 
     view = tu.View(
         tu.Group(
@@ -291,7 +302,8 @@ def image_constast_editor_traitsui(obj, **kwargs):
                     editor=BoundsEditor(
                         low_name='vmin_percentile',
                         high_name='vmax_percentile',
-                        format='%.2f')),
+                        **get_format_dict('%.2f'),
+                        )),
             show_border=True,
             ),
         tu.Group(
@@ -309,8 +321,9 @@ def image_constast_editor_traitsui(obj, **kwargs):
                     visible_when='norm == "Power"',
                     editor=tu.RangeEditor(low=0.1,
                                           high=3.,
-                                          format='%.3f',
-                                          mode="slider"),
+                                          mode="slider",
+                                          **get_format_dict('%.2f'),
+                                          ),
                     ),
             tu.Item('linthresh',
                     label='Linear threshold',
@@ -318,8 +331,9 @@ def image_constast_editor_traitsui(obj, **kwargs):
                     visible_when='norm == "Symlog"',
                     editor=tu.RangeEditor(low=0.01,
                                           high=1.,
-                                          format='%.3f',
-                                          mode="slider"),
+                                          mode="slider",
+                                          **get_format_dict('%.2f'),
+                                          ),
                     ),
             tu.Item('linscale',
                     label='Linear scale',
@@ -327,8 +341,9 @@ def image_constast_editor_traitsui(obj, **kwargs):
                     visible_when='norm == "Symlog"',
                     editor=tu.RangeEditor(low=0.,
                                           high=10.,
-                                          format='%.3f',
-                                          mode="slider"),
+                                          mode="slider",
+                                          **get_format_dict('%.2f'),
+                                          ),
                     ),
             show_border=True,
             ),

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     python_requires='~=3.7',
-    install_requires=['hyperspy>=1.6.2', 'traitsui>=6.0'],
+    install_requires=['traits>=5.0', 'hyperspy>=1.6.2', 'traitsui>=6.1'],
     extras_require={
         'tests': ['pytest'],
         'coverage':["pytest-cov", "codecov"]},


### PR DESCRIPTION
There is currently a traistui deprecation warning when running the test suite:
```python
=============================== warnings summary ===============================
hyperspy_gui_traitsui/tests/test_tools.py::test_image_contrast_tool
hyperspy_gui_traitsui/tests/test_tools.py::test_image_contrast_tool
hyperspy_gui_traitsui/tests/test_tools.py::test_image_contrast_tool
hyperspy_gui_traitsui/tests/test_tools.py::test_image_contrast_tool
  /opt/hostedtoolcache/Python/3.9.12/x64/lib/python3.9/site-packages/traitsui/editor_factory.py:81: DeprecationWarning: Use of format trait is deprecated. Use format_str instead.
    HasPrivateTraits.__init__(self, **traits)

hyperspy_gui_traitsui/tests/test_tools.py::test_image_contrast_tool
  /opt/hostedtoolcache/Python/3.9.12/x64/lib/python3.9/site-packages/traitsui/qt4/extra/bounds_editor.py:44: DeprecationWarning: Use of format trait is deprecated. Use format_str instead.
    self.format = factory.format
```

Even if this is not obvious where it comes from the [traitsui changelog](https://docs.enthought.com/traitsui/changelog.html#release-7-3-0), this deprecation has been introduced in traitsui 7.3.0 (https://github.com/enthought/traitsui/pull/1684) and will be removed in traitsui 8.0.

- [x] Fix deprecation warning form traitsui
- [x] add oldest supported version of dependencies build to github CI 
- [x] set minimum requirement of traits (5.0) and traitsui (6.1)
- [x] add changelog entry