### PR TITLE
Fix import tools error when running hyperspy test suite

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,9 @@
   Add a single entry in the corresponding section below.
   See https://keepachangelog.com for details
 
-## v1.6.0.dev0 (UNRELEASED)
+## v1.5.1.dev0 (UNRELEASED)
+
+* Fix import tools error when running hyperspy test suite ([#47](https://github.com/hyperspy/hyperspy_gui_traitsui/pull/47))
 
 ## v1.5.0 (2022-04-26)
 

--- a/hyperspy_gui_traitsui/tools.py
+++ b/hyperspy_gui_traitsui/tools.py
@@ -2,7 +2,6 @@ from packaging.version import Version
 
 import traitsui
 import traitsui.api as tu
-from traitsui.file_dialog import FileEditor
 from traitsui.menu import OKButton, CancelButton, OKCancelButtons
 
 from hyperspy_gui_traitsui.axes import get_navigation_sliders_group
@@ -312,7 +311,7 @@ def smooth_butterworth(obj, **kwargs):
 @add_display_arg
 def load(obj, **kwargs):
     view = tu.View(
-        tu.Group(tu.Item('filename', editor=FileEditor(dialog_style='open')),
+        tu.Group(tu.Item('filename', editor=tu.FileEditor(dialog_style='open')),
                   "lazy"),
         kind='livemodal',
         buttons=[OKButton, CancelButton],


### PR DESCRIPTION
Unknow why it happen but removing the import fixes it. It only happen when running the hyperspy test suite, otherwise, it works fine... Example:

```python
____________________ test_find_peaks_interactive[local_max] ____________________
[gw1] linux -- Python 3.7.12 /opt/hostedtoolcache/Python/3.7.12/x64/bin/python

method = 'local_max'

    @pytest.mark.skipif(not GUI_INSTALLED, reason="no GUI available")
    @pytest.mark.parametrize('method', PEAK_METHODS)
    def test_find_peaks_interactive(method):
        if method == 'stat':
            pytest.importorskip("sklearn")
        s = DATASETS[0]
>       s.find_peaks(method=method, template=DISC)

hyperspy/tests/signals/test_find_peaks2D.py:220: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
hyperspy/_signals/signal2d.py:1022: in find_peaks
    pf2D.gui(display=display, toolkit=toolkit)
hyperspy/ui_registry.py:163: in pg
    toolkit=toolkit, **kwargs)
hyperspy/ui_registry.py:132: in get_gui
    specs["module"]),
/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1006: in _gcd_import
    ???
<frozen importlib._bootstrap>:983: in _find_and_load
    ???
<frozen importlib._bootstrap>:967: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:677: in _load_unlocked
    ???
<frozen importlib._bootstrap_external>:728: in exec_module
    ???
<frozen importlib._bootstrap>:219: in _call_with_frames_removed
    ???
/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/hyperspy_gui_traitsui/tools.py:5: in <module>
    from traitsui.file_dialog import FileEditor
/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/traitsui/file_dialog.py:385: in <module>
    class FileExistsHandler(Handler):
/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/traitsui/file_dialog.py:402: in FileExistsHandler
    editor=ImageEditor(image="@icons:dialog-warning"),
/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/traitsui/editor_factory.py:81: in __init__
    HasPrivateTraits.__init__(self, **traits)
/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pyface/ui_traits.py:133: in validate
    self.error(object, name, value)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <pyface.ui_traits.Image object at 0x7fefb34ce950>
object = <traitsui.editors.image_editor.ImageEditor object at 0x7fef8b6bc170>
    volume.save()
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pyface/image/image.py", line 580, in save
    images_code = self.images_code
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pyface/image/image.py", line 757, in _get_images_code
    images = ",\n".join(info.image_info_code for info in self.images)
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pyface/image/image.py", line 736, in _images_default
    return self._load_image_info()
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pyface/image/image.py", line 843, in _load_image_info
    old_image.width = cur_image.width
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pyface/image/image.py", line 368, in _width_default
    width, self.height = image.image_size(image.create_image())
AttributeError: 'ImageResource' object has no attribute 'image_size'
------------------------------ Captured log call -------------------------------
ERROR    pyface.ui_traits:ui_traits.py:72 Can't load image resource '@icons:dialog-warning'.
ERROR    pyface.ui_traits:ui_traits.py:73 'ImageResource' object has no attribute 'image_size'
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pyface/ui_traits.py", line 70, in convert_image
    result = ImageLibrary.image_resource(value)
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pyface/image/image.py", line 988, in image_resource
    volume = self.find_volume(image_name)
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pyface/image/image.py", line 1005, in find_volume
    catalog = self.catalog
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pyface/image/image.py", line [1256](https://github.com/ericpre/hyperspy/runs/6274740116?check_suite_focus=true#step:8:1256), in _catalog_default
    return dict([(volume.name, volume) for volume in self.volumes])
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pyface/image/image.py", line 1236, in _volumes_default
    result.extend(self._add_path(join(get_resource_path(1), "library")))
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pyface/image/image.py", line [1295](https://github.com/ericpre/hyperspy/runs/6274740116?check_suite_focus=true#step:8:1295), in _add_path
    volume = self._add_volume(join(path, base))
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pyface/image/image.py", line 1349, in _add_volume
    volume.save()
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pyface/image/image.py", line 580, in save
    images_code = self.images_code
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pyface/image/image.py", line 757, in _get_images_code
    images = ",\n".join(info.image_info_code for info in self.images)
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pyface/image/image.py", line 736, in _images_default
    return self._load_image_info()
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pyface/image/image.py", line 843, in _load_image_info
    old_image.width = cur_image.width
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pyface/image/image.py", line 368, in _width_default
    width, self.height = image.image_size(image.create_image())
AttributeError: 'ImageResource' object has no attribute 'image_size'
```