### PR TITLE
Fix closing `crop_signal1D`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ## v1.6.0.dev0 (UNRELEASED)
 
+* Fix error when pressing "OK" button after "Apply" was pressed in `crop_signal1D` ([#49](https://github.com/hyperspy/hyperspy_gui_traitsui/pull/49))
 
 ## v1.5.1 (2022-05-03)
 

--- a/hyperspy_gui_traitsui/tests/test_axes.py
+++ b/hyperspy_gui_traitsui/tests/test_axes.py
@@ -1,7 +1,6 @@
 
 import numpy as np
 import hyperspy.api as hs
-import pytest
 
 from hyperspy_gui_traitsui.tests.utils import KWARGS
 
@@ -33,11 +32,6 @@ class TestAxes:
 
 
 def test_non_uniform_axes():
-    try:
-        from hyperspy.axes import UniformDataAxis
-    except ImportError:
-        pytest.skip("HyperSpy version doesn't support non-uniform axis")
-
     dict0 = {'scale': 1.0, 'size':2}
     dict1 = {'expression': 'a / (x+b)', 'a': 1240, 'b': 1, 'size': 3,
              'name': 'plumage', 'units': 'beautiful', 'navigate': False}

--- a/hyperspy_gui_traitsui/tests/test_tools.py
+++ b/hyperspy_gui_traitsui/tests/test_tools.py
@@ -16,12 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-from packaging.version import Version
-
 import numpy as np
-import pytest
 
-import hyperspy
 import hyperspy.api as hs
 from hyperspy.signal_tools import (
     ImageContrastEditor,
@@ -57,8 +53,6 @@ def test_image_contrast_tool():
         assert ceditor.norm == norm
 
 
-@pytest.mark.skipif(Version(hyperspy.__version__) < Version("1.7.0.dev"),
-                    reason="Only supported for hyperspy>=1.7")
 def test_remove_background_tool():
 
     s = hs.datasets.artificial_data.get_core_loss_eels_signal(True, False)
@@ -72,8 +66,6 @@ def test_remove_background_tool():
     assert s.isig[:500.0].data.mean() < 1
 
 
-@pytest.mark.skipif(Version(hyperspy.__version__) < Version("1.7.0.dev"),
-                    reason="Only supported for hyperspy>=1.7")
 def test_signal_2d_calibration():
     s = hs.signals.Signal2D(np.zeros((100, 100)))
     s.plot()
@@ -86,8 +78,6 @@ def test_signal_2d_calibration():
     assert s.axes_manager[1].scale == 2
 
 
-@pytest.mark.skipif(Version(hyperspy.__version__) < Version("1.7.0.dev"),
-                    reason="Only supported for hyperspy>=1.7")
 def test_signal_2d_calibration_3d_data():
     s = hs.signals.Signal2D(np.zeros((5, 100, 100)))
     s.plot()

--- a/hyperspy_gui_traitsui/tools.py
+++ b/hyperspy_gui_traitsui/tools.py
@@ -96,10 +96,12 @@ class SpanSelectorInSignal1DHandler(tu.Handler):
 class Signal1DRangeSelectorHandler(tu.Handler):
 
     def close(self, info, is_ok):
-        # Removes the span selector from the plot
-        info.object.span_selector_switch(False)
         if is_ok is True:
             self.apply(info)
+
+        # Removes the span selector from the plot
+        info.object.span_selector_switch(False)
+
         return True
 
     def apply(self, info, *args, **kwargs):
@@ -107,11 +109,16 @@ class Signal1DRangeSelectorHandler(tu.Handler):
 
         """
         obj = info.object
-        if obj.ss_left_value != obj.ss_right_value:
-            info.object.span_selector_switch(False)
-            for method, cls in obj.on_close:
-                method(cls, obj.ss_left_value, obj.ss_right_value)
-            info.object.span_selector_switch(True)
+        extents = obj.span_selector.extents
+        # when the traits and span extent are out of sync, which happen after
+        # "apply" and before making a new selection
+        if obj.ss_left_value == obj.ss_right_value or extents[0] == extents[1]:
+            return
+
+        obj.span_selector_switch(False)
+        for method, cls in obj.on_close:
+            method(cls, obj.ss_left_value, obj.ss_right_value)
+        obj.span_selector_switch(True)
 
         obj.is_ok = True
 


### PR DESCRIPTION
Fix the following:

```python
import hyperspy.api as hs
import numpy as np

s = hs.signals.Signal1D(np.arange(10))
s.crop_signal1D()
# Select a selection on the plot
# press "Apply"
# press "OK"
```

An error arise and the dialog will not close.