### PR TITLE
Remove third party action release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,9 +89,9 @@ jobs:
 
       - name: Run test suite
         # run the tests headlessly
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: pytest --pyargs hyperspy_gui_traitsui
+        run: |
+          sudo apt-get install xvfb
+          xvfb-run pytest --pyargs hyperspy_gui_traitsui
 
       - name: Publish wheels to PyPI
         if: github.repository_owner == 'hyperspy'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,11 +75,22 @@ jobs:
             ./dist/*.whl
             ./dist/*.tar.gz
 
+      - name: 'Install Ubuntu packages for Qt'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install qt5-default
+          sudo apt-get install libxkbcommon-x11-0
+          sudo apt-get install libxcb-icccm4
+          sudo apt-get install libxcb-image0
+          sudo apt-get install libxcb-keysyms1
+          sudo apt-get install libxcb-randr0
+          sudo apt-get install libxcb-render-util0
+          sudo apt-get install libxcb-xinerama0
+
       - name: Install Dependencies
         run: |
           pip install pyqt5
-          sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0
-
 
       - name: Install package
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,9 +108,9 @@ jobs:
 
       - name: Run test suite
         # run the tests headlessly
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: pytest ${{ env.PYTEST_ARGS }} ${{ matrix.PYTEST_ARGS_COVERAGE }}
+        run: |
+          sudo apt-get install xvfb
+          xvfb-run pytest ${{ env.PYTEST_ARGS }} ${{ matrix.PYTEST_ARGS_COVERAGE }}
 
       - name: Upload coverage to Codecov
         if: contains( matrix.PYTEST_ARGS_COVERAGE, 'cov')


### PR DESCRIPTION
As there is limited benefit to use the `GabrielBB/xvfb-action` action, we don't use it to avoid any potential security issue with third party actions - in this case, it could affect files released on pypi.

Release workflow tested in https://github.com/ericpre/hyperspy_gui_traitsui/actions/runs/3082745613.