### PR TITLE
Fix github workflows: replace missing Ubuntu qt5-default package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install qt5-default
+          sudo apt-get install qtbase5-dev
           sudo apt-get install libxkbcommon-x11-0
           sudo apt-get install libxcb-icccm4
           sudo apt-get install libxcb-image0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install qt5-default
+          sudo apt-get install qtbase5-dev
           sudo apt-get install libxkbcommon-x11-0
           sudo apt-get install libxcb-icccm4
           sudo apt-get install libxcb-image0


### PR DESCRIPTION
In the most recent Ubuntu LTS (22.04), the metapackage qt5-default has been removed. This commit removes the qt5-default package from release.yml and tests.yml, and replaces it with qtbase5-dev.

-------------

Note: the tests are still failing, but this is due to the recent `traitsui` `8.0.0` release . This had some API breaking changes, specifically:

- `'traitsui.qt4` being changed to `traitsui.qt`

So I left this for a separate pull request