### PR TITLE
Update for hyperspy 2.0

### DIFF
--- a/hyperspy_gui_traitsui/tools.py
+++ b/hyperspy_gui_traitsui/tools.py
@@ -540,11 +540,8 @@ def spikes_removal_traitsui(obj, **kwargs):
         ),
         tu.Group(
             'add_noise',
-            'interpolator_kind',
             'default_spike_width',
-            tu.Group(
-                'spline_order',
-                enabled_when='interpolator_kind == "Spline"'),
+            'spline_order',
             show_border=True,
             label='Advanced settings'),
     ),


### PR DESCRIPTION
- Remove `interpolator_kind` in spikes removal tool after its removal from hyperspy