### PR TITLE
Hyperspy 2.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,8 +32,7 @@ jobs:
             PIP_SELECTOR: '[tests, coverage]'
             LABEL: -RnMajor-coverage
             PYTEST_ARGS_COVERAGE: --cov=. --cov-report=xml
-          - os: ubuntu
-            PYTHON_VERSION: '3.8'
+          - PYTHON_VERSION: '3.8'
             OLDEST_SUPPORTED_VERSION: true
             # Matching setup.py
             DEPENDENCIES: traits==5.0 traitsui==6.1 pyqt5==5.12.0
@@ -41,6 +40,10 @@ jobs:
             # Hang at the end of the test suite run...
             #PYTEST_ARGS_COVERAGE: --cov=. --cov-report=xml
             LABEL: -RnMajor-oldest
+          - PYTHON_VERSION: '3.8'
+            PIP_ARGS: --pre --upgrade
+            LABEL: -mininum-RnMajor
+            PIP_SELECTOR: '[tests]'
 
     steps:
       - uses: actions/checkout@v4
@@ -90,6 +93,12 @@ jobs:
         if: contains( matrix.LABEL, 'RnPatch')
         run: |
           pip install https://github.com/hyperspy/hyperspy/archive/RELEASE_next_patch.zip
+
+      - name: Install exSpy
+        if: "!contains( matrix.LABEL, 'mininum')"
+        shell: bash
+        run: |
+          pip install https://github.com/hyperspy/exspy/archive/main.zip
 
       - name: Install Dependencies
         run: |

--- a/hyperspy_gui_traitsui/hyperspy_extension.yaml
+++ b/hyperspy_gui_traitsui/hyperspy_extension.yaml
@@ -55,13 +55,13 @@ GUI:
       hyperspy.Model1D.fit_component:
         module: hyperspy_gui_traitsui.model
         function: fit_component_traitsui
-      hyperspy.microscope_parameters_EELS:
+      exspy.microscope_parameters_EELS:
         module: hyperspy_gui_traitsui.microscope_parameters
         function: microscope_parameters_EELS
-      hyperspy.microscope_parameters_EDS_SEM:
+      exspy.microscope_parameters_EDS_SEM:
         module: hyperspy_gui_traitsui.microscope_parameters
         function: microscope_parameters_EDS_SEM
-      hyperspy.microscope_parameters_EDS_TEM:
+      exspy.microscope_parameters_EDS_TEM:
         module: hyperspy_gui_traitsui.microscope_parameters
         function: microscope_parameters_EDS_TEM
       hyperspy.SpanROI:

--- a/hyperspy_gui_traitsui/hyperspy_extension.yaml
+++ b/hyperspy_gui_traitsui/hyperspy_extension.yaml
@@ -13,6 +13,9 @@ GUI:
       hyperspy.Preferences:
         module: hyperspy_gui_traitsui.preferences
         function: preferences_traitsui
+      exspy.Preferences:
+        module: hyperspy_gui_traitsui.preferences
+        function: exspy_preferences_traitsui
       hyperspy.DataAxis:
         module: hyperspy_gui_traitsui.axes
         function: axis_gui

--- a/hyperspy_gui_traitsui/preferences.py
+++ b/hyperspy_gui_traitsui/preferences.py
@@ -19,6 +19,18 @@ PREFERENCES_VIEW = tui.View(
               label='GUIs'),
     tui.Group(tui.Item('Plot', style='custom', show_label=False, ),
               label='Plot'),
+    title='Preferences',
+    buttons=[SaveButton, CancelButton],
+    handler=PreferencesHandler,)
+
+
+@add_display_arg
+def preferences_traitsui(obj, **kwargs):
+    obj.trait_view("traits_view", PREFERENCES_VIEW)
+    return obj, {}
+
+
+EXSPY_PREFERENCES_VIEW = tui.View(
     tui.Group(tui.Item('EELS', style='custom', show_label=False, ),
               label='EELS'),
     tui.Group(tui.Item('EDS', style='custom', show_label=False, ),
@@ -29,6 +41,6 @@ PREFERENCES_VIEW = tui.View(
 
 
 @add_display_arg
-def preferences_traitsui(obj, **kwargs):
-    obj.trait_view("traits_view", PREFERENCES_VIEW)
+def exspy_preferences_traitsui(obj, **kwargs):
+    obj.trait_view("traits_view", EXSPY_PREFERENCES_VIEW)
     return obj, {}

--- a/hyperspy_gui_traitsui/tests/test_tools.py
+++ b/hyperspy_gui_traitsui/tests/test_tools.py
@@ -17,6 +17,7 @@
 # along with  HyperSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
+import pytest
 
 import hyperspy.api as hs
 from hyperspy.signal_tools import (
@@ -54,8 +55,8 @@ def test_image_contrast_tool():
 
 
 def test_remove_background_tool():
-
-    s = hs.datasets.artificial_data.get_core_loss_eels_signal(True, False)
+    exspy = pytest.importorskip("exspy")
+    s = exspy.data.EELS_MnFe(True, False)
     s.plot()
 
     BgR = BackgroundRemoval(s)


### PR DESCRIPTION
Same as https://github.com/hyperspy/hyperspy_gui_ipywidgets/pull/48. Required for the `Release_next_major` branch of Hyperspy since https://github.com/hyperspy/hyperspy/pull/3202 has been merged.