### PR TITLE
Fix for matplotlib 3.10.dev and other tidy up

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,19 +72,15 @@ jobs:
           sudo apt-get install libxcb-render-util0
           sudo apt-get install libxcb-xinerama0
 
-      - name: Install HyperSpy (RELEASE_next_major)
+      - name: Install HyperSpy (RELEASE_next_minor)
         if: contains( matrix.LABEL, 'RnM')
         run: |
-          # pip install git+https://github.com/hyperspy/hyperspy.git@RELEASE_next_major
-          # revert back when hyperspy 2.1 is released 
           pip install git+https://github.com/hyperspy/hyperspy.git@RELEASE_next_minor
 
       - name: Install HyperSpy (RELEASE_next_patch)
         if: contains( matrix.LABEL, 'RnP')
         run: |
-          # pip install git+https://github.com/hyperspy/hyperspy.git@RELEASE_next_patch
-          # revert back when hyperspy 2.1 is released 
-          pip install git+https://github.com/hyperspy/hyperspy.git@RELEASE_next_minor
+          pip install git+https://github.com/hyperspy/hyperspy.git@RELEASE_next_patch
 
       - name: Install exSpy
         if: ${{ ! contains( matrix.LABEL, 'minimum') }}

--- a/hyperspy_gui_traitsui/__init__.py
+++ b/hyperspy_gui_traitsui/__init__.py
@@ -107,7 +107,7 @@ _logger.debug('Current MPL backend: %s', backend)
 if "WX" in backend:
     set_ets_toolkit("wx")
 elif "Qt" in backend:
-    set_ets_toolkit("qt4")
+    set_ets_toolkit("qt")
 elif ETSConfig.toolkit == "":
     # The toolkit has not been set and no supported toolkit is available, so
     # setting it to "null"

--- a/hyperspy_gui_traitsui/__init__.py
+++ b/hyperspy_gui_traitsui/__init__.py
@@ -101,12 +101,12 @@ def set_ets_toolkit(toolkit):
 
 
 # Get the backend from matplotlib
-backend = matplotlib.get_backend()
+backend = matplotlib.get_backend().lower()
 _logger.debug('Loading hyperspy.traitsui_gui')
 _logger.debug('Current MPL backend: %s', backend)
-if "WX" in backend:
+if "wx" in backend:
     set_ets_toolkit("wx")
-elif "Qt" in backend:
+elif "qt" in backend:
     set_ets_toolkit("qt")
 elif ETSConfig.toolkit == "":
     # The toolkit has not been set and no supported toolkit is available, so


### PR DESCRIPTION
Similar as https://github.com/hyperspy/hyperspy/pull/3367.

Other tidying up:
- Use `qt` instead of `qt4` when setting `ETSConfig.toolkit`.
- Remove empty `conftest.py` file.
