### PR TITLE
Group Plot preferences by trait metadata sections

### DIFF
--- a/hyperspy_gui_traitsui/preferences.py
+++ b/hyperspy_gui_traitsui/preferences.py
@@ -20,6 +20,7 @@
 import traitsui.api as tui
 from traitsui.menu import CancelButton
 
+from hyperspy.misc.utils import grouped_editable_traits
 from hyperspy_gui_traitsui.buttons import SaveButton
 from hyperspy_gui_traitsui.utils import add_display_arg
 
@@ -31,13 +32,25 @@ class PreferencesHandler(tui.Handler):
         info.object.save()
         return True
 
+
+def _plot_groups():
+    """Build tui.Group items for the Plot tab from grouped editable traits."""
+    from hyperspy.defaults_parser import preferences
+
+    grouped = grouped_editable_traits(preferences.Plot)
+    groups = []
+    for label, traits in grouped.items():
+        content = [tui.Item(f"Plot.{trait_name}") for trait_name in traits]
+        groups.append(tui.Group(*content, label=label, show_border=True))
+    return groups
+
+
 PREFERENCES_VIEW = tui.View(
     tui.Group(tui.Item('General', style='custom', show_label=False, ),
               label='General'),
     tui.Group(tui.Item('GUIs', style='custom', show_label=False, ),
               label='GUIs'),
-    tui.Group(tui.Item('Plot', style='custom', show_label=False, ),
-              label='Plot'),
+    tui.Group(*_plot_groups(), layout='tabbed', label='Plot'),
     title='Preferences',
     buttons=[SaveButton, CancelButton],
     handler=PreferencesHandler,)

--- a/hyperspy_gui_traitsui/preferences.py
+++ b/hyperspy_gui_traitsui/preferences.py
@@ -20,7 +20,11 @@
 import traitsui.api as tui
 from traitsui.menu import CancelButton
 
-from hyperspy.misc.utils import grouped_editable_traits
+try:
+    from hyperspy.misc.utils import grouped_editable_traits
+except ImportError:
+    grouped_editable_traits = None
+
 from hyperspy_gui_traitsui.buttons import SaveButton
 from hyperspy_gui_traitsui.utils import add_display_arg
 
@@ -34,8 +38,15 @@ class PreferencesHandler(tui.Handler):
 
 
 def _plot_groups():
-    """Build tui.Group items for the Plot tab from grouped editable traits."""
+    """Build tui.Group items for the Plot tab from grouped editable traits.
+
+    When ``grouped_editable_traits`` is not available (hyperspy < 2.5),
+    falls back to a single flat ``Item('Plot', style='custom')``.
+    """
     from hyperspy.defaults_parser import preferences
+
+    if grouped_editable_traits is None:
+        return [tui.Item('Plot', style='custom')]
 
     grouped = grouped_editable_traits(preferences.Plot)
     groups = []

--- a/hyperspy_gui_traitsui/preferences.py
+++ b/hyperspy_gui_traitsui/preferences.py
@@ -40,7 +40,7 @@ def _plot_groups():
     grouped = grouped_editable_traits(preferences.Plot)
     groups = []
     for label, traits in grouped.items():
-        content = [tui.Item(f"Plot.{trait_name}") for trait_name in traits]
+        content = [tui.Item(f"object.Plot.{trait_name}") for trait_name in traits]
         groups.append(tui.Group(*content, label=label, show_border=True))
     return groups
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
   "Operating System :: MacOS",
 ]
 dependencies = [
-  "hyperspy>=2.3.0",
+  "hyperspy>=2.5.0",
   "traits>=6.3", # to match traitsui requirement
   "traitsui>=7.3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
   "Operating System :: MacOS",
 ]
 dependencies = [
-  "hyperspy>=2.5.0",
+  "hyperspy>=2.3.0",
   "traits>=6.3", # to match traitsui requirement
   "traitsui>=7.3",
 ]


### PR DESCRIPTION
Closes #? (to be linked).

## Summary

Replaces the flat `tui.Item('Plot', style='custom')` with tabbed `tui.Group` sections
using `grouped_editable_traits()` from `hyperspy.misc.utils`.

The helper reads `CTrait.group` metadata to organize the growing list of key-binding
preferences into logical sections: General, Navigation, Plot Interaction, Widget Resize,
Model Plot.

## Dependencies

Requires `hyperspy>=2.5.0` (for `grouped_editable_traits()`).

## Related

- hyperspy PR: https://github.com/hyperspy/hyperspy/pull/3632